### PR TITLE
Update Database.c

### DIFF
--- a/core/Database.c
+++ b/core/Database.c
@@ -838,7 +838,7 @@ static const struct cartridge_db db_list[] =
          1,
          1,
          0,
-         0,
+         2,
          0,
          0,
          0


### PR DESCRIPTION
Updated flags setting to 2 for Kung Fu Master, as per the original Prosystem.DAT fle in original Windows source to correct compatibility issues.