### PR TITLE
Stub out nonworking serialization code

### DIFF
--- a/core/libretro.c
+++ b/core/libretro.c
@@ -221,12 +221,14 @@ size_t retro_serialize_size(void)
 
 bool retro_serialize(void *data, size_t size)
 { 
-   return prosystem_Save((char*)data, false);
+   return false;
+   /*return prosystem_Save((char*)data, false);*/
 }
 
 bool retro_unserialize(const void *data, size_t size)
 {
-   return prosystem_Load((const char*)data);
+   return false;
+   /*return prosystem_Load((const char*)data);*/
 }
 
 void retro_cheat_reset(void)


### PR DESCRIPTION
Unserialization doesn't work. This breaks netplay, and is also confusing for regular use, since the serialize button appears to work but states cannot be loaded. This has been [reported on multiple systems](https://github.com/libretro/prosystem-libretro/issues/12).

I have not diagnosed the error, I have just stubbed out the nonworking code, so at least frontends aren't lied to.