### PR TITLE
database correction

### DIFF
--- a/Database.c
+++ b/Database.c
@@ -220,13 +220,13 @@ static const struct cartridge_db db_list[] =
       0
    },
    {
-      "3e63be18e480fa63fce5e4c823286e53",
+      "aefb78276913e8a166e460222e378fec",
       "Beef Drop",
       0,
       true,
       1,
       1,
-      1,
+      0,
       0,
       0,
       0,
@@ -532,7 +532,7 @@ static const struct cartridge_db db_list[] =
          0
       },
       {
-         "12626E21E9EF33CE42E7BAEB68B0D4D9"
+         "59ca19c4b024fdfcd25b75ac836c7749"
          "Double Dragon (Sprite & Color Hack RC7)",
          6,
          false,
@@ -545,7 +545,7 @@ static const struct cartridge_db db_list[] =
          0
       },
       {
-         "558D5BEA768096703DA4D49316FD989D"
+         "098b209aac126f2c2edbc982df09cd1b"
          "Double Dragon (Sprite & Color Hack RC7b)",
          6,
          false,


### PR DESCRIPTION
Incorrect MD5 for Beef Drop might be leading to game not playing correctly.