### PR TITLE
Fix state loading

### DIFF
--- a/core/ProSystem.c
+++ b/core/ProSystem.c
@@ -193,6 +193,7 @@ bool prosystem_Load(const char *buffer)
          return false;
    }
    offset += 16;
+   buffer[offset++];
 
    for(index = 0; index < 4; index++);
    offset += 4;


### PR DESCRIPTION
Restores an offset increment mistakenly removed in e7ff65aa3a33f2ed70a98b8f17f4408551e995a4.