### PR TITLE
Fix savestates and music for "Rikki & Vikki"

### DIFF
--- a/bupboop/coretone/channel.h
+++ b/bupboop/coretone/channel.h
@@ -11,10 +11,10 @@
  * Operating Parameters
  ******************************************************************************/
 /* This indicates the stack depth used to track patch script loops,
- * the default of four should be adequate for most users.
+ * the default of 16 should be adequate for most users.
  */
 #ifndef CORETONE_PATCH_STACKDEPTH
-	#define CORETONE_PATCH_STACKDEPTH		4
+	#define CORETONE_PATCH_STACKDEPTH		16
 #endif
 
 /******************************************************************************

--- a/bupboop/coretone/music.h
+++ b/bupboop/coretone/music.h
@@ -11,10 +11,10 @@
  * Operating Parameters
  ******************************************************************************/
 /* This indicates the stack depth used to track music script loops,
- * the default of four should be adequate for most users.
+ * the default of 16 should be adequate for most users.
  */
 #ifndef CORETONE_MUSIC_STACKDEPTH
-	#define CORETONE_MUSIC_STACKDEPTH		4
+	#define CORETONE_MUSIC_STACKDEPTH		16
 #endif
 
 /******************************************************************************

--- a/core/BupChip.c
+++ b/core/BupChip.c
@@ -26,6 +26,8 @@
 #include "Cartridge.h"
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
+#include "libretro.h"
 
 #define BUPCHIP_FLAGS_PLAYING   1
 #define BUPCHIP_FLAGS_PAUSED   2
@@ -49,6 +51,18 @@ uint8_t bupchip_current_song;
 
 short bupchip_buffer[CORETONE_BUFFER_LEN * 4];
 
+static void bupchip_ReplaceChar(char *string, char character, char replacement)
+{
+   while(true)
+   {
+      string = strchr(string, '\\');
+      if(string == NULL)
+         return;
+      *string = '/';
+      string++;
+   }
+}
+
 // ----------------------------------------------------------------------------
 // InitFromCDF
 // ----------------------------------------------------------------------------
@@ -62,6 +76,11 @@ bool bupchip_InitFromCDF(const char** cdf, size_t* cdfSize, const char *workingD
    while(fileDataCount < sizeof(fileData) / sizeof(fileData[0]) &&
       (line = cartridge_GetNextNonemptyLine(cdf, cdfSize)) != NULL)
    {
+#ifndef _WIN32
+      /* CDF files always use Windows paths. Convert to Unix-style if necessary. */
+      bupchip_ReplaceChar(line, '\\', '/');
+#endif
+
       if(!cartridge_ReadFile(&fileData[fileDataCount].data, &fileData[fileDataCount].size, line, workingDir))
       {
          free(line);

--- a/core/ProSystem.c
+++ b/core/ProSystem.c
@@ -213,7 +213,6 @@ bool prosystem_Load(const char *buffer)
    uint32_t index;
    char digest[33] = {0};
    uint32_t date   = 0;
-   uint32_t size   = 0;
    uint32_t offset = 0;
 
    for(index = 0; index < 16; index++)
@@ -253,20 +252,12 @@ bool prosystem_Load(const char *buffer)
 
    if(cartridge_type == CARTRIDGE_TYPE_SUPERCART_RAM)
    {
-      /* Save state file has an invalid size. */
-      if(size != 32829)
-         return false;
-
       for(index = 0; index < 16384; index++)
          memory_ram[16384 + index] = buffer[offset + index];
       offset += 16384; 
    }
    else if(cartridge_type == CARTRIDGE_TYPE_SOUPER)
    {
-      /* Save state file has an invalid size. */
-      if(size != 49221)
-         return false;
-
       cartridge_souper_chr_bank[0] = buffer[offset++];
       cartridge_souper_chr_bank[1] = buffer[offset++];
       cartridge_souper_mode = buffer[offset++];

--- a/core/libretro.c
+++ b/core/libretro.c
@@ -409,7 +409,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 
 size_t retro_serialize_size(void) 
 { 
-   return 32829;
+   return 49221;
 }
 
 bool retro_serialize(void *data, size_t size)


### PR DESCRIPTION
This pull request builds upon #71 in these two ways:

* It increases some internal limits in the music code. The author of the BupBoop library got in touch with me and told me that this was necessary to play the music from "Rikki & Vikki" properly.
* It fixes save state saving and loading. Before, save states would possibly crash, because the size was not properly stored. It's possible that this addresses #12, because this is a general fix.