### PR TITLE
Clean up `bupchip_ReplaceChar` to actually use its arguments.

### DIFF
--- a/core/BupChip.c
+++ b/core/BupChip.c
@@ -56,9 +56,9 @@ static void bupchip_ReplaceChar(char *string, char character, char replacement)
 {
    while(true)
    {
-      if (!(string = strchr(string, '\\')))
+      if (!(string = strchr(string, character)))
          return;
-      *string = '/';
+      *string = replacement;
       string++;
    }
 }


### PR DESCRIPTION
This is just a little code cleanup that shouldn't affect functionality. Sorry about this, I should have caught this before submitting.