### PR TITLE
Add PAL bios support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@ prosystem-libretro
 ==================
 
 Port of ProSystem to libretro.
+Bios are optionals.
+Place them in your RetroArch/libretro "System Directory" folder.
 
-Place "7800 BIOS (U).rom" (optional) in your RetroArch/libretro "System Directory" folder.
+NTSC/US bios name: "7800 BIOS (U).rom" 
+PAL/EU bios name:  "7800 BIOS (E).rom" 

--- a/core/libretro.c
+++ b/core/libretro.c
@@ -544,14 +544,19 @@ bool retro_load_game(const struct retro_game_info *info)
             (const uint8_t*)info->data, info->size))
       return false;
 
+   database_Load(cartridge_digest);
+
    environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_directory_c);
 
    /* BIOS is optional */
-   sprintf(biospath, "%s%c%s", system_directory_c, slash, "7800 BIOS (U).rom");
+   if (cartridge_region == REGION_PAL)
+      sprintf(biospath, "%s%c%s", system_directory_c, slash, "7800 BIOS (E).rom");
+   else
+      sprintf(biospath, "%s%c%s", system_directory_c, slash, "7800 BIOS (U).rom");
+   
    if (bios_Load(biospath))
       bios_enabled = true;
 
-   database_Load(cartridge_digest);
    prosystem_Reset();
 
    display_ResetPalette();


### PR DESCRIPTION
PAL games refuse to start if NTSC bios is used (only one supported).
This pull request add support of PAL bios if a PAL game is detected.
It should close #75 and #70 and #59