### PR TITLE
Fix save state loading

### DIFF
--- a/core/ProSystem.c
+++ b/core/ProSystem.c
@@ -193,7 +193,7 @@ bool prosystem_Save(char *buffer, bool compress)
 bool prosystem_Load(const char *buffer)
 {
    uint32_t index;
-   char digest[33];
+   char digest[33] = {0};
    uint32_t offset = 0;
 
    for(index = 0; index < 16; index++)


### PR DESCRIPTION
I noticed that save states were no longer loading on the latest build of the core (on Win10 x64 anyway, I do not use RA on other platforms to know if it impacts all others as well).

Bisected the issue to [763ad22](https://github.com/libretro/prosystem-libretro/commit/763ad22c7de51c8f06d6be0d49c554ce6a94a29b) 

Reverting one line on that commit seems to fix the state loading issue.